### PR TITLE
Make IPXE boot process more robust

### DIFF
--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -59,6 +59,15 @@ sub poweron_host {
     }
 }
 
+sub set_pxe_boot {
+    while (1) {
+        my $stdout = ipmitool('chassis bootparam get 5');
+        last if $stdout =~ m/Force PXE/;
+	ipmitool("chassis bootdev pxe");
+        sleep(3);
+    }
+}
+
 sub set_bootscript {
     my $host        = get_required_var('SUT_IP');
     my $ip          = inet_ntoa(inet_aton($host));
@@ -96,7 +105,7 @@ sub run {
 
     set_bootscript;
 
-    ipmitool('chassis bootdev pxe');
+    set_pxe_boot;
     poweron_host;
 
     select_console 'sol', await_console => 0;


### PR DESCRIPTION
It can happen, that ipmi commands get lost in the network. For power control we
already poll the ipmi device and set the desired state until it can be
confirmed.
However, the "force boot via PXE" did quite often not work as intended, and it
looks like a lost package or so. In order to avoid this in the future, we
should poll the ipmi device until the correct boot device is stored and set it
again until we can confirm success.

Signed-off-by: Michael Moese <mmoese@suse.de>

[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: https://progress.opensuse.org/issues/xyz
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
