### PR TITLE
Add schedule for installing sles4asp on baremetal

### DIFF
--- a/schedule/kernel/sles4sap/installation/install_sles4sap_baremetal.yaml
+++ b/schedule/kernel/sles4sap/installation/install_sles4sap_baremetal.yaml
@@ -1,0 +1,64 @@
+---
+name: install_sles4sap_dvd
+description: >
+  Installation tests for SLES4SAP, use the DVD to boot the installer.
+
+  Can be used to install sles4sap on baremetal machines using ipxe_install
+vars:
+  DESKTOP: textmode
+  GRUB_TIMEOUT: 300
+  IPXE: 1
+  IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de:8080
+  HANA: nfs://1c119.qa.suse.de/srv/nfs/sap/HANA2/SPS04rev46/x86_64
+  INSTANCE_SID: NDB
+  INSTANCE_ID: '00'
+schedule:
+  - installation/ipxe_install
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - '{{sles4sap_product_installation_mode}}'
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/releasenotes
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_kdump
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - boot/reconnect_mgmt_console
+  - installation/first_boot
+  - console/system_prepare
+  - '{{test_sles4sap}}'
+  - '{{scc_deregister}}'
+  - '{{generate_image}}'
+conditional_schedule:
+  sles4sap_product_installation_mode:
+    SYSTEM_ROLE:
+      default:
+        - installation/sles4sap_product_installation_mode
+  test_sles4sap:
+    TEST_SLES4SAP:
+      1:
+        - sles4sap/patterns
+        - sles4sap/sapconf
+        - sles4sap/saptune
+  scc_deregister:
+    SCC_DEREGISTER:
+      1:
+        - console/scc_deregistration
+  generate_image:
+    GENERATE_IMAGE:
+      1:
+        - console/hostname
+        - console/force_scheduled_tasks
+        - shutdown/grub_set_bootargs
+        - shutdown/cleanup_before_shutdown
+        - shutdown/shutdown

--- a/schedule/kernel/sles4sap/installation/setup_hana_baremetal.yaml
+++ b/schedule/kernel/sles4sap/installation/setup_hana_baremetal.yaml
@@ -1,0 +1,46 @@
+---
+name: install_sles4sap_dvd
+description: >
+  Installation tests for SLES4SAP, use the DVD to boot the installer.
+
+  Can be used to install sles4sap on baremetal machines using ipxe_install
+vars:
+  DESKTOP: textmode
+  GRUB_TIMEOUT: 300
+  HANA: nfs://1c119.qa.suse.de/srv/nfs/sap/HANA2/SPS04rev46/x86_64
+  INSTANCE_SID: NDB
+  INSTANCE_ID: '00'
+  INSTANCE_TYPE: HBD
+  START_AFTER_TEST: sles4sap_online_dvd_gnome
+  WMP_TEST_REPO: https://gitlab.suse.de/lpalovsky/wmp_basic_tests/-/archive/master/wmp_basic_tests-master.tgz
+schedule:
+  - boot/boot_to_desktop
+  - console/system_prepare
+  - '{{test_sles4sap}}'
+  - '{{scc_deregister}}'
+  - '{{generate_image}}'
+conditional_schedule:
+  sles4sap_product_installation_mode:
+    SYSTEM_ROLE:
+      default:
+        - installation/sles4sap_product_installation_mode
+  test_sles4sap:
+    TEST_SLES4SAP:
+      1:
+        - sles4sap/hana_install
+        - sles4sap/wmp_setup
+        - sles4sap/wmp_basic_test
+        #- reboot?
+        #- sles4sap/wmp_basic_test
+  scc_deregister:
+    SCC_DEREGISTER:
+      1:
+        - console/scc_deregistration
+  generate_image:
+    GENERATE_IMAGE:
+      1:
+        - console/hostname
+        - console/force_scheduled_tasks
+        - shutdown/grub_set_bootargs
+        - shutdown/cleanup_before_shutdown
+        - shutdown/shutdown


### PR DESCRIPTION
This is mostly a copy of the install_sles4sap.yaml with some changes for
baremetal installation on kernel qa machines. While we are working on
this, we decided to fork away schedules for our work, and merge things
back later, to avoid confusion and errors.