### PR TITLE
Allow disk space for HANA volume group to be expanded

### DIFF
--- a/schedule/kernel/sles4sap/installation/install_sles4sap_baremetal.yaml
+++ b/schedule/kernel/sles4sap/installation/install_sles4sap_baremetal.yaml
@@ -12,6 +12,7 @@ vars:
   HANA: nfs://1c119.qa.suse.de/srv/nfs/sap/HANA2/SPS04rev46/x86_64
   INSTANCE_SID: NDB
   INSTANCE_ID: '00'
+  SEPARATE_HOME: 0
 schedule:
   - installation/ipxe_install
   - installation/welcome

--- a/schedule/kernel/sles4sap/installation/setup_hana_baremetal.yaml
+++ b/schedule/kernel/sles4sap/installation/setup_hana_baremetal.yaml
@@ -28,6 +28,7 @@ conditional_schedule:
     TEST_SLES4SAP:
       1:
         - sles4sap/hana_install
+        - kernel/prepare_sles4sap
         - sles4sap/wmp_setup
         - sles4sap/wmp_basic_test
         #- reboot?

--- a/tests/kernel/prepare_sles4sap.pm
+++ b/tests/kernel/prepare_sles4sap.pm
@@ -1,0 +1,41 @@
+# SUSE's openQA tests
+#
+# Copyright © 2021 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# do some additional preparations for sles4sap testing on our baremetal machines
+#
+# Maintainer: Michael Moese <mmoese@suse.de>
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+
+sub run {
+    my $self = shift;
+
+    $self->select_serial_terminal;
+
+    my $disk = script_output('TMP=$(pvdisplay -C -o pv_name,vg_name | grep system | cut -d \' \' -f 3); echo ${TMP::-1}');
+    my $part = $disk . "3";
+    my $is_hana = script_run("pvdisplay -C -o pv_name,vg_name | grep vg_hana");
+
+    assert_script_run("echo ',,V' | sfdisk $disk --force --append");
+    assert_script_run("partprobe");
+    assert_script_run("pvcreate $part");
+    assert_script_run("vgextend vg_hana $part");
+    assert_script_run("lvextend -L +63G /dev/vg_hana/lv_hanashared");
+    assert_script_run("xfs_growfs /hana/shared");
+    assert_script_run("lvextend -L +63G /dev/vg_hana/lv_hanadata");
+    assert_script_run("xfs_growfs /hana/data");
+
+}
+
+1;


### PR DESCRIPTION
Add remaining space on system disk to hana volume group

Signed-off-by: Michael Moese <mmoese@suse.com>

[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: https://progress.opensuse.org/issues/xyz
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
